### PR TITLE
Use 'include-dirs' instead of 'cpp-options'.

### DIFF
--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -29,7 +29,7 @@ Library
         
         Other-Modules:          System.Console.ANSI.Common
         
-        Cpp-Options:            -Iincludes
+        Include-Dirs:           includes
         
         if os(windows)
                 Build-Depends:          Win32 >= 2.0


### PR DESCRIPTION
Fixes a Cabal warning.
