### PR TITLE
Added missing instances

### DIFF
--- a/System/Console/ANSI/Common.hs
+++ b/System/Console/ANSI/Common.hs
@@ -1,5 +1,6 @@
 module System.Console.ANSI.Common where
 
+import Data.Ix
 
 -- | ANSI colors: come in various intensities, which are controlled by 'ColorIntensity'
 data Color = Black
@@ -10,32 +11,35 @@ data Color = Black
            | Magenta
            | Cyan
            | White
-           deriving (Bounded, Enum, Show)
+           deriving (Eq, Ord, Bounded, Enum, Show, Read, Ix)
 
 -- | ANSI colors come in two intensities
 data ColorIntensity = Dull
                     | Vivid
-                    deriving (Enum, Show)
+                    deriving (Eq, Ord, Bounded, Enum, Show, Read, Ix)
 
 -- | ANSI colors can be set on two different layers
 data ConsoleLayer = Foreground
                   | Background
-                  deriving (Enum, Show)
+                  deriving (Eq, Ord, Bounded, Enum, Show, Read, Ix)
 
 -- | ANSI blink speeds: values other than 'NoBlink' are not widely supported
 data BlinkSpeed = SlowBlink -- ^ Less than 150 blinks per minute
                 | RapidBlink -- ^ More than 150 blinks per minute
                 | NoBlink
+                deriving (Eq, Ord, Bounded, Enum, Show, Read, Ix)
 
 -- | ANSI text underlining
 data Underlining = SingleUnderline
                  | DoubleUnderline -- ^ Not widely supported
                  | NoUnderline
+                 deriving (Eq, Ord, Bounded ,Enum, Show, Read, Ix)
 
 -- | ANSI general console intensity: usually treated as setting the font style (e.g. 'BoldIntensity' causes text to be bold)
 data ConsoleIntensity = BoldIntensity
                       | FaintIntensity -- ^ Not widely supported: sometimes treated as concealing text
                       | NormalIntensity
+                      deriving (Eq, Ord, Bounded, Enum, Show, Read, Ix)
 
 -- | ANSI Select Graphic Rendition command
 data SGR = Reset
@@ -46,3 +50,4 @@ data SGR = Reset
          | SetVisible Bool -- ^ Not widely supported
          | SetSwapForegroundBackground Bool
          | SetColor ConsoleLayer ColorIntensity Color
+         deriving (Eq, Ord, Show, Read)

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -1,5 +1,5 @@
 Name:                ansi-terminal
-Version:             0.5.5.1
+Version:             0.6
 Cabal-Version:       >= 1.2
 Category:            User Interfaces
 Synopsis:            Simple ANSI terminal support, with Windows compatibility


### PR DESCRIPTION
As I prepare for a 1.0 release, I was working on converting `trifecta` over from its own internal `wl-pprint-terminfo` to use `ansi-terminal` and along the way I found myself needing a number of the instances that are missing from types provided by `ansi-terminal`.

I've attached a pull request that adds the instances.

I cannot reasonably provide them outside of the package with orphans, but since its adding instances, it does require a version bump. =/
